### PR TITLE
add section type to section properties

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -213,6 +213,10 @@ abstract class Parser
                 // иначе пытаемся добавить её в свойство документа
                 $this->addProperty($key, $value);
             }
+            else
+            {
+                $this->tmpSection[$key] = $value;
+            }
         }
     }
 

--- a/src/section/Document.php
+++ b/src/section/Document.php
@@ -16,6 +16,10 @@ class Document extends Section
     /** @type array Список возможных свойств */
     protected static $propertiesSettings = [
         // Шапка платежного документа
+        'СекцияДокумент' => [
+            'required' => true,
+            'type' => 'строка',
+        ],
         'Номер' => [
             'required' => true,
             'type' => 'строка',


### PR DESCRIPTION
Добавил название секции в свойства секции
```
СекцияДокумент=Банковский ордер
СекцияДокумент=Платежное поручение
```

Раньше нельзя было добраться до свойств «Банковский ордер», «Платежное поручение». Я сделал, чтобы они выводились в свойствах секции под названием «СекцияДокумент».

Буду рад, если окажется полезным. Спасибо за парсер :-)